### PR TITLE
Minor hotfix - v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ There are some changes on the configuration file, here's the list of changes:
 
 - `masterKey` **REMOVED**, we don't need this anymore
 
-- `apiConfig.rootFolder` **CHANGED**, you need to encrypt the folder ID first  
-  `https://drive-demo.mbaharip.com/api/internal/encrypt?q={{ folderId }}`
+- `apiConfig.rootFolder` **CHANGED**, you need to encrypt the folder ID on your localhost first  
+  `http://localhost:3000/api/internal/encrypt?q={{ folderId }}`
 
 - `apiConfig.proxyThumbnail` **ADDED**, default value is `true`
 - `siteConfig.siteNameTemplate` **ADDED**, default value is `%s - next-gdrive-index`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-gdrive-index",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/src/app/@markdown.tsx
+++ b/src/app/@markdown.tsx
@@ -20,7 +20,7 @@ type Props = {
 };
 export default function Markdown({ content }: Props) {
   return (
-    <div className='markdown w-full rounded-[var(--radius)] bg-muted p-3'>
+    <div className='markdown w-full rounded-[var(--radius)] p-3'>
       <ReactMarkdown
         className='w-full'
         disallowedElements={["script"]}

--- a/src/app/@preview.doc.tsx
+++ b/src/app/@preview.doc.tsx
@@ -16,6 +16,7 @@ type Props = {
 
 export default function PreviewDoc({ file }: Props) {
   const [docSrc, setDocSrc] = useState<string>("");
+  const [docBuffer, setDocBuffer] = useState<ArrayBuffer>();
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string>("");
 
@@ -27,6 +28,10 @@ export default function PreviewDoc({ file }: Props) {
           return;
         }
         const token = await CreateDownloadToken();
+        const buffer = await fetch(
+          `/api/download/${file.encryptedId}?token=${token}`,
+        ).then((res) => res.arrayBuffer());
+        setDocBuffer(buffer);
         setDocSrc(`/api/download/${file.encryptedId}?token=${token}`);
       } catch (error) {
         const e = error as Error;
@@ -69,6 +74,9 @@ export default function PreviewDoc({ file }: Props) {
           documents={[
             {
               uri: docSrc,
+              fileData: docBuffer,
+              fileName: file.name,
+              fileType: file.mimeType,
             },
           ]}
           pluginRenderers={DocViewerRenderers}

--- a/src/app/@preview.unknown.tsx
+++ b/src/app/@preview.unknown.tsx
@@ -26,7 +26,7 @@ export default function PreviewUnknown() {
             size={32}
             className='animate-spin text-foreground'
           />
-          <p>Loading image...</p>
+          <p>Loading content...</p>
         </div>
       ) : (
         <div

--- a/src/app/@preview.video.tsx
+++ b/src/app/@preview.video.tsx
@@ -83,7 +83,7 @@ export default function PreviewVideo({ file }: Props) {
             if (error instanceof Error) {
               setError(error.message);
             } else {
-              setError("An unknown error occurred");
+              setError("Failed to load video. (Probably not supported?)");
             }
           }}
         />

--- a/src/config/gIndex.config.ts
+++ b/src/config/gIndex.config.ts
@@ -6,7 +6,7 @@ const config: z.input<typeof Schema_Config> = {
    * If possible, please don't change this value
    * Even if you're creating a PR, just let me change it myself
    */
-  version: "2.0",
+  version: "2.0.1",
   /**
    * Base path of the app, used for generating links
    *

--- a/src/utils/encryptionHelper/hash.ts
+++ b/src/utils/encryptionHelper/hash.ts
@@ -17,10 +17,17 @@ const key = generateKey();
 const iv = Buffer.from(key);
 
 export async function encryptData(data: string): Promise<string> {
-  const cipher = crypto.createCipheriv("aes-128-cbc", key, iv);
-  return Buffer.concat([cipher.update(data, "utf-8"), cipher.final()]).toString(
-    "hex",
-  );
+  try {
+    const cipher = crypto.createCipheriv("aes-128-cbc", key, iv);
+    return Buffer.concat([
+      cipher.update(data, "utf-8"),
+      cipher.final(),
+    ]).toString("hex");
+  } catch (error) {
+    const e = error as Error;
+    console.error(e.message);
+    throw new Error(e.message);
+  }
 }
 
 export async function decryptData(hash: string): Promise<string> {
@@ -32,6 +39,10 @@ export async function decryptData(hash: string): Promise<string> {
       decipher.final(),
     ]).toString("utf-8");
   } catch (error) {
-    return "";
+    const e = error as Error;
+    console.error(e.message);
+    throw new Error(
+      "Failed to decrypt data, either invalid hash or encryption key.",
+    );
   }
 }

--- a/src/utils/previewHelper.ts
+++ b/src/utils/previewHelper.ts
@@ -17,10 +17,10 @@ const extensionsMap: Record<FileTypes, string[]> = {
     "mp4",
     "mkv",
     "webm",
-    "avi",
-    "mov",
-    "flv",
-    "wmv",
+    // "avi",
+    // "mov",
+    // "flv",
+    // "wmv",
     "mpg",
     "mpeg",
     "m4v",
@@ -131,7 +131,8 @@ export function getFileType(
 export function getPreviewIcon(fileExtension: string, mimeType: string) {
   if (fileExtension === "ts") {
     if (mimeType.includes("video")) {
-      return iconMap["video"];
+      // .ts video are not supported
+      return iconMap["unknown"];
     } else {
       return iconMap["code"];
     }


### PR DESCRIPTION
Changed:
- **Change encrypt URL on [Migration Guide](https://github.com/mbahArip/next-gdrive-index?tab=readme-ov-file#migration-guide) to `localhost` instead of `drive-demo.mbaharip.com`.**
  Since it will encrypt the folder ID using my encryption key instead of the user encryption key.
- **Add proper encryption error handling.**
  Instead of returning empty string, now it will show encryption error. This causing confusion when it fails to decrypt root ID.
- **Update preview formats and handling.**
  Remove a couple of video formats, and also handling document preview (document preview change might be reversed)
- **Remove `bg-muted` from Markdown.**
  For better view.