### PR TITLE
Fix: inconsistence cache between route and gdrive

### DIFF
--- a/src/utils/gdriveInstance.ts
+++ b/src/utils/gdriveInstance.ts
@@ -43,18 +43,17 @@ if (!gdrive) {
   gdrive = google.drive({
     version: "v3",
     auth: serviceAccountAuth,
-    fetchImplementation: (url, init) =>
-      fetch(url, {
-        ...init,
-        next: {
-          revalidate: 3600,
-        },
-      }),
+    fetchImplementation: (url, init) => fetch(url, init),
   });
 }
 export const gdriveNoCache = google.drive({
   version: "v3",
   auth: serviceAccountAuth,
+  fetchImplementation: (url, init) =>
+    fetch(url, {
+      ...init,
+      cache: "no-store",
+    }),
 });
 
 export default gdrive as drive_v3.Drive;


### PR DESCRIPTION
Remove the revalidate options on `google.drive` fetch implementation to fix the inconsistency cache between route and gdrive.
Now it should use route `revalidate` value.

Also add `no-store` cache on `gdriveNoCache`, this function used when fetching the password, download route, and stream route.